### PR TITLE
Add link to the Hackathon Projects discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # Transform 2021 Hackathon
 
 Main repo for the Hackathon of Transform 2021
+
+### See Discussions for information on the Hackathon Projects and how to participate:    
+https://github.com/softwareunderground/transform-2021-hackathon/discussions


### PR DESCRIPTION
It may not be obvious to some folks that the Hackathon Project Descriptions are in 'Discussions'  so adding a link to improve visibility.